### PR TITLE
Adding notes from SwiftUI on watchOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ I watch sessions in 1.5 speed using the awesome player from wwdc.io. This is the
 
 First of all the list is not sorted. If you want to add a new session, please just put it at the bottom. Don't forget to add an entry to the `table of contents` and your name to `Contributors` 🤝
 
-Please send a [GitHub Pull Request](https://github.com/Blackjacx/WWDC/compare) with a some notes of what you have done (read more about [pull requests](http://help.github.com/pull-requests/)).
+Please send a [GitHub Pull Request](https://github.com/Blackjacx/WWDC/compare) with some notes of what you have done (read more about [pull requests](http://help.github.com/pull-requests/)).
 
 Try to write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
 

--- a/README.md
+++ b/README.md
@@ -1245,3 +1245,49 @@ https://developer.apple.com/wwdc19/418
   - Metal takes advantage of GPU of the underlying Mac system
   - Texture storage modes are different on macOS/iOS
   - Always test performance on actual devices! (For additional infos `38:30`) 
+
+## SwiftUI on watchOS
+
+https://developer.apple.com/wwdc19/219
+
+- **watchOS 6**
+  - Independent watchOS apps (decoupled from iOS apps)
+  - Extended run-time sessions
+  - Building experiences: Complications, Notifications, Siri, etc.
+  - Prioritize quick interactions
+- **Full Power of SwiftUI**
+  - **Declarative syntax** Whole new UI framework, new fetures and APIs
+  - **Integration** Watchkit controllers with SwiftUI Views 
+  	- `InterfaceController` inherits `WKHostingController`
+  - **Lists** WatchOS flash cards app
+	- Keep model and List in sync using @ObjectBinding
+	- Use `Command + Click` to bring up the inspector and use different contextual options while coding
+	- Use `.listStyle(.carousel)` to get the carousel effect while scrolling the list
+	- Swipe to delete, drag to reorder
+	- Use `.onMove` and `.onDelete` blocks to manage the movement and deletion of items in the list
+  - **Interactive Notifications** Timely and contextual info
+  	- Short look (Info from payload + App icon) Immediately upon wrist raise
+	- Long look (Scrolling interface with custom body and action buttons)
+	- `NotificationController` inherits `WKUserNotificationHostingController`
+		- `didReceive` method allows us to extract info from notification
+		- `body` property is re-evaluated after `didReceive` is called
+  - **Digital Crown** Series 4 watch can make use of haptic crown (e.g. workout app, custom timer)
+  	- Building following custom interfaces requires `.digitalCrowRotation` and `.focusable` modifier
+  	- Free scrolling interface (no concrete spots between elements)
+		- binding (source of truth)
+		- from
+		- through
+	- Picking between discrete elements
+		- binding (source of truth)
+		- from
+		- through
+		- by (stride along which haptic feedback is provided)
+	- Moving around circles (not limited to either end of the sequence) 
+		- binding (source of truth)
+		- from
+		- through
+		- by (stride along which haptic feedback is provided)
+		- sensitivity (how much rotation need to be applied to move from one element to the next)
+		- isContinuous (don't stop at either limit of sequence)
+		
+		

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Feel free to submit a `PR` if I got something wrong or you have an improvement s
 
 Thanks so much to EVERYBODY who contributed and improved the overall quality of the notes and those who added complete notes to the list:
 
-[@matthew_spear](https://twitter.com/matthew_spear), [@rukano](https://github.com/rukano), [@Borzoo](https://github.com/Borzoo), [@viktorasl](https://github.com/viktorasl), [@ezefranca](https://github.com/ezefranca), [@0xflotus](https://github.com/0xflotus), [@lachlanjc](https://github.com/lachlanjc), [@Sherlouk](https://github.com/Sherlouk), [@serralvo](https://github.com/serralvo), [@Gerriet](https://github.com/gerriet), [@soucolline](https://github.com/soucolline), [@DmIvanov](https://github.com/DmIvanov), [@tommy60703](https://github.com/tommy60703)
+[@matthew_spear](https://twitter.com/matthew_spear), [@rukano](https://github.com/rukano), [@Borzoo](https://github.com/Borzoo), [@viktorasl](https://github.com/viktorasl), [@ezefranca](https://github.com/ezefranca), [@0xflotus](https://github.com/0xflotus), [@lachlanjc](https://github.com/lachlanjc), [@Sherlouk](https://github.com/Sherlouk), [@serralvo](https://github.com/serralvo), [@Gerriet](https://github.com/gerriet), [@soucolline](https://github.com/soucolline), [@DmIvanov](https://github.com/DmIvanov), [@tommy60703](https://github.com/tommy60703), [@speedoholic](https://github.com/speedoholic)
 
 ## Mentions
 
@@ -76,6 +76,7 @@ This repo has been already mentioned in the following places:
 * [Creating Great Localized Experiences with Xcode 11](#creating-great-localized-experiences-with-xcode-11)
 * [Introducing Combine](#introducing-combine)
 * [Getting the Most Out of Simulator](#getting-the-most-out-of-simulator)
+* [SwiftUI on watchOS](#swiftui-on-watchos)
 
 ## What's New in Swift
 


### PR DESCRIPTION
- Adding notes from SwifUI on watchOS video (30 minutes long)
- Adding speedoholic to list of contributors
- Fixing typo in CONTRIBUTING.md

This WWDC19 video was 30 minutes long and was focusing more on the demo side than theory. I have made some notes to jot down the key methods and properties that were explained during the demo. I have also included some benefits that SwiftUI brings to watchOS along with the WatchKit integration details.